### PR TITLE
Add support for all hlfabric platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ The preparation:
 Next, a launcher pod is created and has the following properties:
 - The name is `{{ peer pod name}}-cc-{{ chaincode label }}-{{ short hash }}`
 - It has the temporary subdirectories of the transfer PV mounted
-- The command starts the chaincode
+- The platform/language dependant command starts the chaincode
 
 The created pod is watched until it exits.
 Afterwards this procedure is executed:

--- a/build.go
+++ b/build.go
@@ -101,7 +101,8 @@ func Build(ctx context.Context, cfg Config) error {
 
 	// Create build information
 	buildInformation := BuildInformation{
-		Image: pod.Spec.Containers[0].Image,
+		Image:    pod.Spec.Containers[0].Image,
+		Platform: metadata.Type,
 	}
 
 	bi, err := json.Marshal(buildInformation)

--- a/example/demo/network.sh
+++ b/example/demo/network.sh
@@ -76,6 +76,7 @@ function networkUp() {
   kubectl apply -f k8s/components
   kubectl wait --for=condition=ready pod/$(kubectl get pod -l app=cli.peer0.org1.example.com -o jsonpath="{.items[0].metadata.name}")
   kubectl cp chaincodes/fabcar.tar.gz $(kubectl get pod -l app=cli.peer0.org1.example.com -o jsonpath="{.items[0].metadata.name}"):/chaincodes
+  kubectl cp chaincodes/marbles02.tar.gz $(kubectl get pod -l app=cli.peer0.org1.example.com -o jsonpath="{.items[0].metadata.name}"):/chaincodes
 }
 
 function networkDown() {

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/fsouza/go-dockerclient v1.6.3 // indirect
 	github.com/hyperledger/fabric v2.1.0+incompatible
 	github.com/hyperledger/fabric-amcl v0.0.0-20200424173818-327c9e2cf77a // indirect
-	github.com/hyperledger/fabric-protos-go v0.0.0-20200124220212-e9cfc186ba7b // indirect
+	github.com/hyperledger/fabric-protos-go v0.0.0-20200124220212-e9cfc186ba7b
 	github.com/otiai10/copy v1.1.2-0.20200311132357-7ca34007d073
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/viper v1.6.2 // indirect

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.13
 require (
 	github.com/fsouza/go-dockerclient v1.6.3 // indirect
 	github.com/hyperledger/fabric v2.1.0+incompatible
+	github.com/hyperledger/fabric-amcl v0.0.0-20200424173818-327c9e2cf77a // indirect
 	github.com/hyperledger/fabric-protos-go v0.0.0-20200124220212-e9cfc186ba7b // indirect
 	github.com/otiai10/copy v1.1.2-0.20200311132357-7ca34007d073
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -120,6 +120,7 @@ github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORR
 github.com/gorilla/mux v1.7.4/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
+github.com/grpc-ecosystem/go-grpc-middleware v1.0.0 h1:Iju5GlWwrvL6UBg4zJJt3btmonfrMlCDdsejg4CZE7c=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
@@ -136,6 +137,8 @@ github.com/hyperledger/fabric v2.0.1+incompatible h1:7W+yG0gLKTC7NLcWPT3vfpnasez
 github.com/hyperledger/fabric v2.0.1+incompatible/go.mod h1:tGFAOCT696D3rG0Vofd2dyWYLySHlh0aQjf7Q1HAju0=
 github.com/hyperledger/fabric v2.1.0+incompatible h1:U7Qhq4h8u3LOfd7NIYDqxtouIWdcg4pHpgZ0IyvZem4=
 github.com/hyperledger/fabric v2.1.0+incompatible/go.mod h1:tGFAOCT696D3rG0Vofd2dyWYLySHlh0aQjf7Q1HAju0=
+github.com/hyperledger/fabric-amcl v0.0.0-20200424173818-327c9e2cf77a h1:JAKZdGuUIjVmES0X31YUD7UqMR2rz/kxLluJuGvsXPk=
+github.com/hyperledger/fabric-amcl v0.0.0-20200424173818-327c9e2cf77a/go.mod h1:X+DIyUsaTmalOpmpQfIvFZjKHQedrURQ5t4YqquX7lE=
 github.com/hyperledger/fabric-protos-go v0.0.0-20200124220212-e9cfc186ba7b h1:rZ3Vro68vStzLYfcSrQlprjjCf5UmFk7QjKGgHL8IQg=
 github.com/hyperledger/fabric-protos-go v0.0.0-20200124220212-e9cfc186ba7b/go.mod h1:xVYTjK4DtZRBxZ2D9aE4y6AbLaPwue2o/criQyQbVD0=
 github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=

--- a/main.go
+++ b/main.go
@@ -129,7 +129,8 @@ type Config struct {
 
 // BuildInformation is used to serialize build data for consumption by the launcher
 type BuildInformation struct {
-	Image string
+	Image    string
+	Platform string
 }
 
 // ChaincodeMetadata is based on
@@ -154,6 +155,7 @@ type ChaincodeRunConfig struct {
 	// Custom fields
 	ShortName string
 	Image     string
+	Platform  string
 }
 
 func streamPodLogs(ctx context.Context, pod *apiv1.Pod) error {

--- a/platform.go
+++ b/platform.go
@@ -22,6 +22,9 @@ func GetPlatform(ccType string) platforms.Platform {
 
 // GetRunArgs returns the chaincode run arguments as defined by HyperLedger Fabric Peer
 func GetRunArgs(ccType, peerAddress string) []string {
+	// platforms are defined as uppercase in protobuf
+	ccType = strings.ToUpper(ccType)
+
 	dvm := dockercontroller.DockerVM{}
 	args, err := dvm.GetArgs(ccType, peerAddress)
 	if err != nil {
@@ -35,6 +38,9 @@ func GetRunArgs(ccType, peerAddress string) []string {
 // GetMountDir returns the mount directory for the chaincode depending on the platform.
 // This is required as DockerVM.GetArgs assumes a platform dependend setup.
 func GetCCMountDir(ccType string) string {
+	// platforms are defined as uppercase in protobuf
+	ccType = strings.ToUpper(ccType)
+
 	switch ccType {
 	case pb.ChaincodeSpec_GOLANG.String():
 		// https://github.com/hyperledger/fabric/blob/v2.1.1/core/chaincode/platforms/golang/platform.go#L192

--- a/platform.go
+++ b/platform.go
@@ -1,9 +1,11 @@
 package main
 
 import (
+	"log"
 	"strings"
 
 	"github.com/hyperledger/fabric/core/chaincode/platforms"
+	"github.com/hyperledger/fabric/core/container/dockercontroller"
 )
 
 // GetPlatform returns the chaincode platform as defined by HyperLedger Fabric Peer
@@ -15,4 +17,16 @@ func GetPlatform(ccType string) platforms.Platform {
 	}
 
 	return nil
+}
+
+// GetRunArgs returns the chaincode run arguments as defined by HyperLedger Fabric Peer
+func GetRunArgs(ccType, peerAddress string) []string {
+	dvm := dockercontroller.DockerVM{}
+	args, err := dvm.GetArgs(ccType, peerAddress)
+	if err != nil {
+		log.Println("dockercontroller.GetArgs returned %q, but we will use a default", err)
+		return []string{"chaincode", "-peer.address", peerAddress}
+	}
+
+	return args
 }

--- a/run.go
+++ b/run.go
@@ -177,6 +177,7 @@ func getChaincodeRunConfig(metadataDir string, outputDir string) (*ChaincodeRunC
 	}
 
 	metadata.Image = buildInformation.Image
+	metadata.Platform = buildInformation.Platform
 
 	return &metadata, nil
 }
@@ -261,11 +262,7 @@ func createChaincodePod(ctx context.Context,
 							Value: hasTLS,
 						},
 					},
-					Command: []string{
-						"/chaincode/output/chaincode",
-						"-peer.address",
-						runConfig.PeerAddress,
-					},
+					Command:   GetRunArgs(runConfig.Platform, runConfig.PeerAddress),
 					Resources: apiv1.ResourceRequirements{Limits: limits},
 					VolumeMounts: []apiv1.VolumeMount{
 						{

--- a/run.go
+++ b/run.go
@@ -262,8 +262,9 @@ func createChaincodePod(ctx context.Context,
 							Value: hasTLS,
 						},
 					},
-					Command:   GetRunArgs(runConfig.Platform, runConfig.PeerAddress),
-					Resources: apiv1.ResourceRequirements{Limits: limits},
+					WorkingDir: GetCCMountDir(runConfig.Platform), // Set the CWD to the path where the chaincode is
+					Command:    GetRunArgs(runConfig.Platform, runConfig.PeerAddress),
+					Resources:  apiv1.ResourceRequirements{Limits: limits},
 					VolumeMounts: []apiv1.VolumeMount{
 						{
 							Name:      "transfer-pv",
@@ -273,7 +274,7 @@ func createChaincodePod(ctx context.Context,
 						},
 						{
 							Name:      "transfer-pv",
-							MountPath: "/chaincode/output/",
+							MountPath: GetCCMountDir(runConfig.Platform),
 							SubPath:   transferPVPrefix + "/output/",
 							ReadOnly:  true,
 						},


### PR DESCRIPTION
Fixes #6 

Changes:
- Platform dependend build and run argument handling
- Proper artefact location handling on run
- Additional base64 encoded keys and certs for the node platform
- Added marbles02 example

Validation with node platform:
```
bash-5.0# peer lifecycle chaincode install /chaincodes/marbles02.tar.gz 
2020-07-02 13:19:10.366 CEST [cli.lifecycle.chaincode] submitInstallProposal -> INFO 001 Installed remotely: response:<status:200 payload:"\nLmarbles02_1:7caaa04a5315e1f5239c4259f6179a1e95246e9384387b96a13a04024a8feb75\022\013marbles02_1" > 
2020-07-02 13:19:10.367 CEST [cli.lifecycle.chaincode] submitInstallProposal -> INFO 002 Chaincode code package identifier: marbles02_1:7caaa04a5315e1f5239c4259f6179a1e95246e9384387b96a13a04024a8feb75
bash-5.0#

bash-5.0# peer lifecycle chaincode queryinstalled
Installed chaincodes on peer:
Package ID: marbles02_1:7caaa04a5315e1f5239c4259f6179a1e95246e9384387b96a13a04024a8feb75, Label: marbles02_1
bash-5.0# 

... commiting

bash-5.0# peer lifecycle chaincode  querycommitted -C mychannel
Committed chaincode definitions on channel 'mychannel':
Name: marbles02, Version: 1, Sequence: 1, Endorsement Plugin: escc, Validation Plugin: vscc
bash-5.0# 

bash-5.0# peer chaincode query -C mychannel -n marbles02 -c '{"Args":["initMarble","marble2","red","50","tom"]}'
bash-5.0# peer chaincode query -C mychannel -n marbles02 -c '{"Args":["initMarble","marble3","blue","70","tom"]}'
bash-5.0# peer chaincode query -C mychannel -n marbles02 -c '{"Args":["transferMarble","marble2","jerry"]}'
Error: endorsement failure during query. response: status:500 message:"error in simulation: transaction returned with failure: Error: marble does not exist" 
bash-5.0# peer chaincode query -C mychannel -n marbles02 -c '{"Args":["transferMarblesBasedOnColor","blue","jerry"]}'
```

Chaincode log:
```
$ kubectl logs -f peer0.org2.example.com-6cb5fc7b8-gvtz4-cc-marbles02-1-7caaa04a
+ CHAINCODE_DIR=/usr/local/src
+ cd /usr/local/src
+ npm start -- --peer.address peer0-org2-example-com:7052

> marbles@1.0.0 start /usr/local/src
> node marbles_chaincode.js "--peer.address" "peer0-org2-example-com:7052"

2020-07-02T12:28:00.931Z info [c-api:lib/chaincode.js]                            Registering with peer peer0-org2-example-com:7052 as chaincode "marbles02_1:7caaa04a5315e1f5239c4259f6179a1e95246e9384387b96a13a04024a8feb75"  
2020-07-02T12:28:01.025Z info [c-api:lib/handler.js]                              Successfully registered with peer node. State transferred to "established"  
2020-07-02T12:28:01.025Z info [c-api:lib/handler.js]                              Successfully established communication with peer node. State transferred to "ready"  
{ fcn: 'initLedger', params: [] }
=========== Instantiated Marbles Chaincode ===========
2020-07-02T12:31:33.333Z info [c-api:lib/handler.js]                              [mychannel-2f482e0c] Calling chaincode Init() succeeded. Sending COMPLETED message back to peer  
Transaction ID: 37bb1942326209ac7fc4e0868391117eff464ce08e53827f5ab3161acee3c821
```