### PR TITLE
upgrade fabric to v2.3.0 and k8scc to v0.0.6

### DIFF
--- a/.github/workflows/ci-k8s.yml
+++ b/.github/workflows/ci-k8s.yml
@@ -23,8 +23,8 @@ jobs:
       run: kind load docker-image k8scc:latest
     - name: Install Hyperledger Fabric binaries
       run: |
-        wget -q https://github.com/hyperledger/fabric/releases/download/v2.2.1/hyperledger-fabric-linux-amd64-2.2.1.tar.gz
-        tar -xvf hyperledger-fabric-linux-amd64-2.2.1.tar.gz bin/
+        wget -q https://github.com/hyperledger/fabric/releases/download/v2.3.0/hyperledger-fabric-linux-amd64-2.3.0.tar.gz
+        tar -xvf hyperledger-fabric-linux-amd64-2.3.0.tar.gz bin/
     - name: Deploy network
       working-directory: ./example/demo/
       timeout-minutes: 3

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 core.yaml.orig
+core.yaml.new
 .idea
 .DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN go env
 RUN go build -o /bin/externalcc .
 
 
-FROM hyperledger/fabric-peer:2.2.1
+FROM hyperledger/fabric-peer:2.3.0
 RUN apk --no-cache add patch
 
 # Install external cc

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ spec:
     spec:
       serviceAccountName: peer                             # run peer as service account
       containers:
-      - image: postfinance/hlfabric-k8scc:2.2.1-k8scc0.0.5 # use an appropriate image and tag
+      - image: postfinance/hlfabric-k8scc:2.3.0-k8scc0.0.6 # use an appropriate image and tag
         - name: K8SCC_CFGFILE
           value: "/opt/k8scc/k8scc.yaml"                   # this points to the default configuration file
         volumeMounts:
@@ -59,8 +59,8 @@ The version tags are defined as follows This allows to create (hotfix) branches 
 - `v{{ k8scc version }}`: tag scheme used internally for k8scc development
 
 Examples:
-- `2.2.1-k8scc0.0.5`: Peer v2.2.1, k8scc v0.0.5
-- `v0.0.5`: k8scc v0.0.5, peer at undefined version
+- `2.3.0-k8scc0.0.6`: Peer v2.3.0, k8scc v0.0.6
+- `v0.0.6`: k8scc v0.0.6, peer at undefined version
 
 ### Releasing
 If you want to release a new version of `k8scc`, do the following:

--- a/core.yaml.md5sum
+++ b/core.yaml.md5sum
@@ -1,1 +1,1 @@
-2bf697bc82cb2f69852368e5a0d29b78  /etc/hyperledger/fabric/core.yaml
+db6a32ec348ecb403340df46c44f3366  /etc/hyperledger/fabric/core.yaml

--- a/core.yaml.patch
+++ b/core.yaml.patch
@@ -1,6 +1,6 @@
---- core.yaml.orig	2020-11-14 12:32:11.000000000 +0100
-+++ core.yaml.new	2020-11-14 12:42:35.000000000 +0100
-@@ -546,12 +546,13 @@
+--- core.yaml.orig	2020-12-11 14:57:56.386337469 -0800
++++ core.yaml.new	2020-12-11 15:16:32.071715590 -0800
+@@ -551,12 +551,13 @@
      # List of directories to treat as external builders and launchers for
      # chaincode. The external builder detection processing will iterate over the
      # builders in the order specified below.
@@ -11,12 +11,12 @@
 -        #      - ENVVAR_NAME_TO_PROPAGATE_FROM_PEER
 -        #      - GOPROXY
 +    externalBuilders:
-+        - name: "k8scc"
-+          path: /opt/k8scc/
-+          propagateEnvironment:
-+          - KUBERNETES_SERVICE_HOST
-+          - KUBERNETES_SERVICE_PORT
-+          - K8SCC_CFGFILE
++      - name: "k8scc"
++        path: /opt/k8scc/
++        propagateEnvironment:
++        - KUBERNETES_SERVICE_HOST
++        - KUBERNETES_SERVICE_PORT
++        - K8SCC_CFGFILE
  
      # The maximum duration to wait for the chaincode build and install process
      # to complete.

--- a/example/demo/k8s/bootstrap/job_setup.yaml
+++ b/example/demo/k8s/bootstrap/job_setup.yaml
@@ -7,7 +7,7 @@ spec:
     spec:
       containers:
       - name: tools
-        image: hyperledger/fabric-tools:2.2.1
+        image: hyperledger/fabric-tools:2.3.0
         imagePullPolicy: IfNotPresent
         workingDir: /etc/hyperledger/fabric/
         command: ["/bin/sh",  "-c"]

--- a/example/demo/k8s/bootstrap/pvc.yaml
+++ b/example/demo/k8s/bootstrap/pvc.yaml
@@ -9,7 +9,6 @@ spec:
   resources:
     requests:
       storage: 1Gi
-  storageClassName: standard
 ---
 kind: PersistentVolumeClaim
 apiVersion: v1
@@ -21,4 +20,3 @@ spec:
   resources:
     requests:
       storage: 5Gi
-  storageClassName: standard

--- a/example/demo/k8s/components/base/cli.peer0.org1.example.com.yaml
+++ b/example/demo/k8s/components/base/cli.peer0.org1.example.com.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
         - name: cli
-          image: hyperledger/fabric-tools:2.2.1
+          image: hyperledger/fabric-tools:2.3.0
           workingDir: /etc/hyperledger/fabric/
           tty: true
           stdin: true

--- a/example/demo/k8s/components/base/cli.peer0.org2.example.com.yaml
+++ b/example/demo/k8s/components/base/cli.peer0.org2.example.com.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
         - name: cli
-          image: hyperledger/fabric-tools:2.2.1
+          image: hyperledger/fabric-tools:2.3.0
           workingDir: /etc/hyperledger/fabric/
           tty: true
           stdin: true

--- a/example/demo/k8s/components/base/orderer.example.com.yaml
+++ b/example/demo/k8s/components/base/orderer.example.com.yaml
@@ -16,7 +16,7 @@ spec:
         app: orderer.example.com
     spec:
       containers:
-      - image: hyperledger/fabric-orderer:2.2.1
+      - image: hyperledger/fabric-orderer:2.3.0
         imagePullPolicy: IfNotPresent
         name: fabric-orderer
         workingDir: /etc/hyperledger/fabric/
@@ -79,4 +79,3 @@ spec:
   resources:
     requests:
       storage: 1Gi
-  storageClassName: standard

--- a/example/demo/k8s/components/base/peer0.org1.example.com.yaml
+++ b/example/demo/k8s/components/base/peer0.org1.example.com.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       serviceAccountName: peer
       containers:
-      - image: postfinance/hlfabric-k8scc:2.2.1-k8scc0.0.5
+      - image: postfinance/hlfabric-k8scc:2.3.0-k8scc0.0.6
         name: fabric-peer
         workingDir: /etc/hyperledger/fabric/
         env:
@@ -107,4 +107,3 @@ spec:
   resources:
     requests:
       storage: 1Gi
-  storageClassName: standard

--- a/example/demo/k8s/components/base/peer0.org2.example.com.yaml
+++ b/example/demo/k8s/components/base/peer0.org2.example.com.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       serviceAccountName: peer
       containers:
-      - image: postfinance/hlfabric-k8scc:2.2.1-k8scc0.0.5
+      - image: postfinance/hlfabric-k8scc:2.3.0-k8scc0.0.6
         name: fabric-peer
         workingDir: /etc/hyperledger/fabric/
         env:
@@ -107,4 +107,3 @@ spec:
   resources:
     requests:
       storage: 1Gi
-  storageClassName: standard

--- a/example/peer.yaml
+++ b/example/peer.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       serviceAccountName: peer
       containers:
-      - image: postfinance/hlfabric-k8scc:2.2.1-k8scc0.0.5
+      - image: postfinance/hlfabric-k8scc:2.3.0-k8scc0.0.6
         name: fabric-peer
         workingDir: /etc/hyperledger/fabric/
         env:

--- a/go.mod
+++ b/go.mod
@@ -6,14 +6,14 @@ require (
 	github.com/Shopify/sarama v1.27.2 // indirect
 	github.com/fsouza/go-dockerclient v1.6.3 // indirect
 	github.com/hashicorp/go-version v1.2.1 // indirect
-	github.com/hyperledger/fabric v1.4.0-rc1.0.20201113143701-bf2ebb609d7a
+	github.com/hyperledger/fabric v1.4.0-rc1.0.20201118191903-ec81f3e74fa1
 	github.com/hyperledger/fabric-amcl v0.0.0-20200424173818-327c9e2cf77a // indirect
-	github.com/hyperledger/fabric-protos-go v0.0.0-20200506201313-25f6564b9ac4
+	github.com/hyperledger/fabric-protos-go v0.0.0-20201028172056-a3136dde2354
 	github.com/otiai10/copy v1.1.2-0.20200311132357-7ca34007d073
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/viper v1.6.2 // indirect
 	github.com/sykesm/zap-logfmt v0.0.3 // indirect
-	gopkg.in/yaml.v2 v2.2.8
+	gopkg.in/yaml.v2 v2.3.0
 	k8s.io/api v0.18.1
 	k8s.io/apimachinery v0.18.1
 	k8s.io/client-go v0.18.1

--- a/go.sum
+++ b/go.sum
@@ -206,6 +206,8 @@ github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/hyperledger/fabric v1.4.0-rc1.0.20201113143701-bf2ebb609d7a h1:J2ZRsLTKPpQAx45qa7iM7K8xNqFdrArtWSaMbS2wThY=
 github.com/hyperledger/fabric v1.4.0-rc1.0.20201113143701-bf2ebb609d7a/go.mod h1:+kicKDn5xa88tOpOY/o6/7iB/RD7oOs2INzwVg2ARmM=
+github.com/hyperledger/fabric v1.4.0-rc1.0.20201118191903-ec81f3e74fa1 h1:6/BCoIqhS0b1DYgwcq3lL2ZaOJTZyzR7YcS9+vGwd+8=
+github.com/hyperledger/fabric v1.4.0-rc1.0.20201118191903-ec81f3e74fa1/go.mod h1:ppiyrJ+sUSk/rAX9cTd8xwAwSQ7chEbOQMAqtQ3pLG4=
 github.com/hyperledger/fabric-amcl v0.0.0-20200128223036-d1aa2665426a/go.mod h1:X+DIyUsaTmalOpmpQfIvFZjKHQedrURQ5t4YqquX7lE=
 github.com/hyperledger/fabric-amcl v0.0.0-20200424173818-327c9e2cf77a h1:JAKZdGuUIjVmES0X31YUD7UqMR2rz/kxLluJuGvsXPk=
 github.com/hyperledger/fabric-amcl v0.0.0-20200424173818-327c9e2cf77a/go.mod h1:X+DIyUsaTmalOpmpQfIvFZjKHQedrURQ5t4YqquX7lE=
@@ -217,6 +219,7 @@ github.com/hyperledger/fabric-protos-go v0.0.0-20190919234611-2a87503ac7c9/go.mo
 github.com/hyperledger/fabric-protos-go v0.0.0-20200424173316-dd554ba3746e/go.mod h1:xVYTjK4DtZRBxZ2D9aE4y6AbLaPwue2o/criQyQbVD0=
 github.com/hyperledger/fabric-protos-go v0.0.0-20200506201313-25f6564b9ac4 h1:75hBp86WljV3uQ7Q/wbO5w8ahfLAzxH7jfT5kVy2n6g=
 github.com/hyperledger/fabric-protos-go v0.0.0-20200506201313-25f6564b9ac4/go.mod h1:xVYTjK4DtZRBxZ2D9aE4y6AbLaPwue2o/criQyQbVD0=
+github.com/hyperledger/fabric-protos-go v0.0.0-20201028172056-a3136dde2354/go.mod h1:xVYTjK4DtZRBxZ2D9aE4y6AbLaPwue2o/criQyQbVD0=
 github.com/ijc/Gotty v0.0.0-20170406111628-a8b993ba6abd/go.mod h1:3LVOLeyx9XVvwPgrt2be44XgSqndprz1G18rSk8KD84=
 github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
@@ -240,6 +243,7 @@ github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGi
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2 h1:DB17ag19krx9CFsz4o3enTrPXyIXCl+2iCXH/aMAp9s=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
+github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
@@ -267,6 +271,7 @@ github.com/mitchellh/mapstructure v1.1.2 h1:fmNYVwqnSfB9mZU6OS2O6GsXM+wcskZDuKQz
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/mapstructure v1.2.2 h1:dxe5oCinTXiTIcfgmZecdCzPmAJKd46KsCWc35r0TV4=
 github.com/mitchellh/mapstructure v1.2.2/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
+github.com/mitchellh/mapstructure v1.3.2/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
@@ -318,6 +323,7 @@ github.com/otiai10/mint v1.3.1 h1:BCmzIS3n71sGfHB5NMNDB3lHYPz8fWSkCAErHed//qc=
 github.com/otiai10/mint v1.3.1/go.mod h1:/yxELlJQ0ufhjUwhshSj+wFjZ78CnZ48/1wtmBH1OTc=
 github.com/pelletier/go-toml v1.2.0 h1:T5zMGML61Wp+FlcbWjRDT7yAxhJNAiPPLOFECq181zc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
+github.com/pelletier/go-toml v1.8.0/go.mod h1:D6yutnOGMveHEPV7VQOuvI/gXY61bv+9bAOTRnLElKs=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
 github.com/pierrec/lz4 v2.5.0+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pierrec/lz4 v2.5.2+incompatible h1:WCjObylUIOlKy/+7Abdn34TLIkXiA4UWUMhxq9m9ZXI=
@@ -326,6 +332,7 @@ github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkg/sftp v1.10.1/go.mod h1:lYOWFsE0bwd1+KfKJaKeuokY15vzFx25BLbzYYoAxZI=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_golang v0.8.0/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
@@ -370,6 +377,7 @@ github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasO
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/afero v1.2.2 h1:5jhuqJyZCZf2JRofRvN/nIFgIWNzPa3/Vz8mYylgbWc=
 github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=
+github.com/spf13/afero v1.3.1/go.mod h1:5KUK8ByomD5Ti5Artl0RtHeI5pTF7MIDuXL3yY520V4=
 github.com/spf13/cast v1.3.0 h1:oget//CVOEoFewqQxwr0Ej5yjygnqGkvggSE/gB35Q8=
 github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/spf13/cast v1.3.1 h1:nFm6S0SMdyzrzcmThSipiEubIDy8WEXKNZ0UOgiRpng=
@@ -385,6 +393,7 @@ github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnIn
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/viper v0.0.0-20150908122457-1967d93db724/go.mod h1:A8kyI5cUJhb8N+3pkfONlcEcZbueH6nhAm0Fq7SrnBM=
+github.com/spf13/viper v1.1.1/go.mod h1:A8kyI5cUJhb8N+3pkfONlcEcZbueH6nhAm0Fq7SrnBM=
 github.com/spf13/viper v1.6.2 h1:7aKfF+e8/k68gda3LOjo5RxiUqddoFxVq4BKBPrxk5E=
 github.com/spf13/viper v1.6.2/go.mod h1:t3iDnF5Jlj76alVNuyFBk5oUMCvsrkbvZK0WQdfDi5k=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
@@ -446,6 +455,7 @@ golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnf
 golang.org/x/crypto v0.0.0-20190211182817-74369b46fc67/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+golang.org/x/crypto v0.0.0-20190820162420-60c769a6c586/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200220183623-bac4c82f6975 h1:/Tl7pH94bvbAAHBdZJT947M/+gp0+CqQXDtMRC0fseo=
 golang.org/x/crypto v0.0.0-20200220183623-bac4c82f6975/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200221231518-2aa609cf4a9d/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
@@ -476,6 +486,7 @@ golang.org/x/net v0.0.0-20190613194153-d28f0bde5980/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20191004110552-13f9640d40b9 h1:rjwSpXsdiK0dV8/Naq3kAw9ymfAeJIyd0upUIElB+lI=
 golang.org/x/net v0.0.0-20191004110552-13f9640d40b9/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20200813134508-3edf25e44fcc/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20200904194848-62affa334b73 h1:MXfv8rhZWmFeqX3GNZRsd6vOLoaCHjYEX3qkRo3YBUA=
 golang.org/x/net v0.0.0-20200904194848-62affa334b73/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
@@ -509,6 +520,7 @@ golang.org/x/sys v0.0.0-20191022100944-742c48ecaeb7 h1:HmbHVPwrPEKPGLAcHSrMe6+hq
 golang.org/x/sys v0.0.0-20191022100944-742c48ecaeb7/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd h1:xhmwyvizuTgC2qz7ZlMluP20uW+C3Rm0FD/WLDX8884=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200819091447-39769834ee22/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.0.0-20160726164857-2910a502d2bf/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -566,6 +578,7 @@ google.golang.org/grpc v1.23.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyac
 google.golang.org/grpc v1.25.1/go.mod h1:c3i+UQWmh7LiEpx4sFZnkU36qjEYZ0imhYfXVyQciAY=
 google.golang.org/grpc v1.29.1 h1:EC2SB8S04d2r73uptxphDSUG+kTKVgjRPF+N3xpxRB4=
 google.golang.org/grpc v1.29.1/go.mod h1:itym6AZVZYACWQqET3MqgPpjcuV5QH3BxFS3IjizoKk=
+google.golang.org/grpc v1.31.0/go.mod h1:N36X2cJ7JwdamYAgDz+s+rVMFjt3numwzf/HckM8pak=
 gopkg.in/airbrake/gobrake.v2 v2.0.9/go.mod h1:/h5ZAUhDkGaJfjzjKLSjv6zCL6O0LLBxU4K+aSYdM/U=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
@@ -603,6 +616,7 @@ gopkg.in/yaml.v2 v2.2.4 h1:/eiJrUcujPVeJ3xlSWaiNi3uSVmDGBK1pDHUHAnao1I=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776 h1:tQIYjPdBoyREyB9XMu+nnTclpTYkz2zFM+lzLJFO4gQ=
 gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/k8scc.yaml
+++ b/k8scc.yaml
@@ -1,8 +1,8 @@
 ---
 images:
-  golang: "hyperledger/fabric-ccenv:2.2.1"
-  java: "hyperledger/fabric-javaenv:2.2.1"
-  node: "hyperledger/fabric-nodeenv:2.2.1"
+  golang: "hyperledger/fabric-ccenv:2.3.0"
+  java: "hyperledger/fabric-javaenv:2.3.0"
+  node: "hyperledger/fabric-nodeenv:2.3.0"
 transfer_volume:
   path: "/var/lib/k8scc/transfer/"
   claim: "k8scc-transfer-pv"

--- a/main.go
+++ b/main.go
@@ -134,7 +134,7 @@ type BuildInformation struct {
 }
 
 // ChaincodeMetadata is based on
-// https://github.com/hyperledger/fabric/blob/v2.2.1/core/chaincode/persistence/chaincode_package.go#L229
+// https://github.com/hyperledger/fabric/blob/v2.3.0/core/chaincode/persistence/chaincode_package.go#L229
 type ChaincodeMetadata struct {
 	Type       string `json:"type"` // golang, java, node
 	Path       string `json:"path"`
@@ -143,7 +143,7 @@ type ChaincodeMetadata struct {
 }
 
 // ChaincodeRunConfig is based on
-// https://github.com/hyperledger/fabric/blob/v2.2.1/core/container/externalbuilder/externalbuilder.go#L335
+// https://github.com/hyperledger/fabric/blob/v2.3.0/core/container/externalbuilder/externalbuilder.go#L335
 type ChaincodeRunConfig struct {
 	CCID        string `json:"chaincode_id"`
 	PeerAddress string `json:"peer_address"`

--- a/platform.go
+++ b/platform.go
@@ -43,13 +43,13 @@ func GetCCMountDir(ccType string) string {
 
 	switch ccType {
 	case pb.ChaincodeSpec_GOLANG.String():
-		// https://github.com/hyperledger/fabric/blob/v2.2.1/core/chaincode/platforms/golang/platform.go#L192
+		// https://github.com/hyperledger/fabric/blob/v2.3.0/core/chaincode/platforms/golang/platform.go#L192
 		return "/usr/local/bin"
 	case pb.ChaincodeSpec_JAVA.String():
-		// https://github.com/hyperledger/fabric/blob/v2.2.1/core/chaincode/platforms/java/platform.go#L125
+		// https://github.com/hyperledger/fabric/blob/v2.3.0/core/chaincode/platforms/java/platform.go#L125
 		return "/root/chaincode-java/chaincode"
 	case pb.ChaincodeSpec_NODE.String():
-		// https://github.com/hyperledger/fabric/blob/v2.2.1/core/chaincode/platforms/node/platform.go#L170
+		// https://github.com/hyperledger/fabric/blob/v2.3.0/core/chaincode/platforms/node/platform.go#L170
 		return "/usr/local/src"
 	default:
 		// Fall back to Go dir

--- a/prepare_release
+++ b/prepare_release
@@ -15,8 +15,8 @@ read K8SCC_VERSION
 
 K8SCC_VERSION_SHORT=$(echo $K8SCC_VERSION | sed 's/v//g')
 
-# Update dependencies (commit hash as a version is just a hack because there is a problem with the new go.mod of fabric)
-go get -u github.com/hyperledger/fabric@bf2ebb609d7a245178d30fc21d24e8fb8c8a4b80
+# Update dependencies (2.3.0) (commit hash as a version is just a hack because there is a problem with the new go.mod of fabric)
+go get -u github.com/hyperledger/fabric@ec81f3e74fa127fc504b1c2249b19ec421ea2a1d
 
 
 # Check diff of core.yaml

--- a/run.go
+++ b/run.go
@@ -19,7 +19,7 @@ import (
 )
 
 // Run implements the chaincode launcher on Kubernetes whose function is implemented after
-// https://github.com/hyperledger/fabric/blob/v2.2.1/integration/externalbuilders/golang/bin/run
+// https://github.com/hyperledger/fabric/blob/v2.3.0/integration/externalbuilders/golang/bin/run
 func Run(ctx context.Context, cfg Config) error {
 	log.Println("Procedure: run")
 
@@ -116,7 +116,7 @@ func createArtifacts(c *ChaincodeRunConfig, dir string) error {
 	}
 
 	// Create weird cert files (used by node platform)
-	// https://github.com/hyperledger/fabric/blob/v2.2.1/core/container/dockercontroller/dockercontroller.go#L319
+	// https://github.com/hyperledger/fabric/blob/v2.3.0/core/container/dockercontroller/dockercontroller.go#L319
 	err = ioutil.WriteFile(clientCertPath, []byte(base64.StdEncoding.EncodeToString([]byte(c.ClientCert))), os.ModePerm)
 	if err != nil {
 		return errors.Wrap(err, "writing client cert file")


### PR DESCRIPTION
Changes:
- bump fabric version
- remove storageClassName from example/demo to be able to run it with MicroK8s